### PR TITLE
wiesbaden: use standard nodelist.json

### DIFF
--- a/Resources/model/domainlist.json
+++ b/Resources/model/domainlist.json
@@ -184,7 +184,7 @@
 		"url": "https://map.funkfeuer.at/wien/data.php"
 	}, {
 		"name": "Wiesbaden",
-		"url": "http://map.wiesbaden.freifunk.net/nodes.json"
+		"url": "http://map.wiesbaden.freifunk.net/data/nodelist.json"
 	}, {
 		"name": "Witten",
 		"url": "http://map.freifunk-ruhrgebiet.de/WIT/nodes.json"


### PR DESCRIPTION
Bitte die URL für Wiesbaden ändern, sodass die native nodelist.json des meshviewers benutzt wird, danke!