### PR TITLE
Update URI for darmstadt

### DIFF
--- a/Resources/model/domainlist.json
+++ b/Resources/model/domainlist.json
@@ -25,7 +25,7 @@
 		"url": "http://map.chemnitz.freifunk.net/nodes.json"
 	}, {
 		"name": "Darmstadt",
-		"url": "http://map.darmstadt.freifunk.net/nodes.json"
+		"url": "https://map.darmstadt.freifunk.net/data/nodelist.json"
 	}, {
 		"name": "Dortmund",
 		"url": "http://map.ffdo.de/data/nodes.json"


### PR DESCRIPTION
Use the newer meshviewer-based `nodelist.json` instead of the old ffmap `nodes.json`. The latter is something we want to retire soon.

Also our websites are only available through https, so this saves one redirect.