### PR TITLE
change node url of mainz

### DIFF
--- a/Resources/model/domainlist.json
+++ b/Resources/model/domainlist.json
@@ -153,7 +153,7 @@
 	}, {
 		"name": "Mainz",
 		"image": "http://florian.altherr.name/wp-content/uploads/2013/04/ffmz_logo.png",
-		"url": "http://map.freifunk-mainz.de/nodes.json"
+		"url": "http://map.freifunk-mainz.de/data/nodelist.json"
 	}, {
 		"name": "Mayen / Koblenz",
 		"url": "http://status.freifunk-myk.de/data/nodes.json",


### PR DESCRIPTION
Freifunk Mainz now uses the Meshviewer - so change the list url to nodelist