### PR TITLE
updated information sources for chemnitz

### DIFF
--- a/Resources/model/domainlist.json
+++ b/Resources/model/domainlist.json
@@ -37,8 +37,8 @@
 		"image": "https://pbs.twimg.com/profile_images/448915312742629377/dbpLOlRn_400x400.png"
 	}, {
 		"name": "Chemnitz",
-		"url": "http://map.chemnitz.freifunk.net/nodes.json",
-		"image": "http://www.chemnitz.freifunk.net/wp-content/uploads/2013/08/frontlogoText.png"
+		"url": "http://meshviewer.chemnitz.freifunk.net/nodes.json",
+		"image": "http://www.chemnitz.freifunk.net/wp-content/uploads/2014/02/ffc.png"
 	}, {
 		"name": "Cottbus",
 		"url": "http://openwifimap.net/api/view_nodes_spatial?bbox=14.0,51.6,14.6,51.8",


### PR DESCRIPTION
Due to the migration to gluon we use the meshviewer now. I also updated the image file the logo. The image without sponsors is better to use.