### PR TITLE
Logo für Freifunk Lippe

### DIFF
--- a/Resources/model/domainlist.json
+++ b/Resources/model/domainlist.json
@@ -174,7 +174,9 @@
 		"url": "https://db.leipzig.freifunk.net/uptime/google_earth/"
 	}, {
 		"name": "Lippe",
+		"image": "https://freifunk-lippe.de/wp-content/uploads/logo_300.png",
 		"url": "https://karte.freifunk-lippe.de/data/nodes.json"
+		
 	}, {
 		"name": "Lübeck",
 		"image": "http://blog.blaudirekt.de/wp-content/uploads/2012/09/Freifunk_Luebeck.png",


### PR DESCRIPTION
https://freifunk-lippe.de/wp-content/uploads/logo_300.png