### PR TITLE
Fix URL for Freifunk Vogtland

### DIFF
--- a/Resources/model/domainlist.json
+++ b/Resources/model/domainlist.json
@@ -318,7 +318,7 @@
 	}, {
 		"name": "Vogtland",
 		"image": "https://vogtland.freifunk.net/wordpress/wp-content/uploads/2017/02/freifunk-vogtland_domain-name_h150.png",
-		"url": "https://vpn01.freifunk-vogtland.net/ffv/nodes.json"
+		"url": "https://mapdata.freifunk-vogtland.net/nodes.json"
 	}, {
 		"name": "Vorderpfalz",
 		"image": "http://test.suedwest-netze.de/wp-content/themes/the-box/images/logo_vp.png",


### PR DESCRIPTION
vpn01.freifunk-vogtland.net was the server which previously gathered the data. This job was now taken over by vpn04.freifunk-vogtland.net. For this reason, the CNAME mapdata.freifunk-vogtland.net should be used to refer to the server which provides map related data for Freifunk Vogtland.